### PR TITLE
Removing "?" character from query

### DIFF
--- a/bots/archi/config/postprocessors.conf
+++ b/bots/archi/config/postprocessors.conf
@@ -1,1 +1,2 @@
 programy.processors.post.denormalize.DenormalizePostProcessor
+programy.processors.post.cleanup.CleanUpPostProcessor

--- a/src/programy/processors/post/cleanup.py
+++ b/src/programy/processors/post/cleanup.py
@@ -28,8 +28,4 @@ class CleanUpPostProcessor(PostProcessor):
         if stripped.endswith(" ."):
             stripped = stripped[:len(stripped)-2] + "."
 
-        first = stripped[:1]
-        rest = stripped[1:]
-        result = first.upper() + rest.lower()
-
-        return result
+        return stripped

--- a/src/programy/processors/pre/cleanup.py
+++ b/src/programy/processors/pre/cleanup.py
@@ -25,4 +25,4 @@ class CleanUpPreProcessor(PreProcessor):
 
     def process(self, bot, clientid, string):
         logging.debug("Cleaning up input...")
-        return string.upper()
+        return string.translate({ord(c): None for c in '?'}).upper()


### PR DESCRIPTION
Check the changes before merging them in.

I restored the change in postprocessors.conf, tinkering instead with the actual content of the python script invoked (src/programy/processors/post/cleanup.py)
I also added an extra step in the preprocessor script to remove the character "?" from the query, because as you pointed out it was causing issues we didn't have before.
I'm pretty sure Pandorabots Playground's own preprocessor did that too.